### PR TITLE
投稿内容が6段以上になった場合に短く省略するためのCSSをFirefoxに対応 #98

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -22115,8 +22115,6 @@ readers do not read off random characters that represent icons */
 }
 
 .row-5 {
-  max-height: 7.5em;
-  line-height: 1.5;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 5;

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -33,8 +33,6 @@
 
 // 投稿の表示行制限
 .row-5 {
-    max-height: calc(1.5em * 5);
-    line-height: 1.5;
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 5;


### PR DESCRIPTION
投稿内容が6段以上になった場合に短く省略するためのCSSをFirefoxに対応
close #98