### PR TITLE
マイページのフォロータブを別ページに移動 #129

### DIFF
--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -19,7 +19,7 @@ class CommentFactory extends Factory
         return [
             'user_id' => User::inRandomOrder()->first(),
             'post_id' => $post,
-            'text' => preg_replace("/。/", "。\n", $this->faker->realText($this->faker->numberBetween(30, 200), 5)),
+            'text' => preg_replace("/。/", "。\n", $this->faker->realText($this->faker->numberBetween(10, 100), 5)),
             'created_at' => $this->faker->dateTimeBetween($post->updated_at, '0days'),
             'updated_at' => $this->faker->dateTimeBetween($post->updated_at, '0days'),
         ];

--- a/resources/views/inc/followTabs.blade.php
+++ b/resources/views/inc/followTabs.blade.php
@@ -1,0 +1,29 @@
+{{-- マイページフォロータブ --}}
+<nav class="nav nav-pills nav-fill flex-column flex-lg-row mb-4">
+
+    <a @class([
+        'nav-link',
+        'flex-lg-fill',
+        'text-lg-center',
+        'text-reset' => !$followeePage,
+        'active' => $followeePage,
+    ]) href="{{ route('users.followees', ['name' => $user->name]) }}" tabindex="-1"
+        aria-disabled="true">
+        <i class="fa-solid fa-users fa-fw"></i>
+        フォロー中
+    </a>
+
+    <a @class([
+        'nav-link',
+        'flex-lg-fill',
+        'text-lg-center',
+        'text-reset' => !$followerPage,
+        'active' => $followerPage,
+    ]) href="{{ route('users.followers', ['name' => $user->name]) }}" tabindex="-1"
+        aria-disabled="true">
+        <i class="fa-solid fa-user fa-fw"></i>
+        フォロワー
+    </a>
+
+</nav>
+{{-- /マイページフォロータブ --}}

--- a/resources/views/inc/tabs.blade.php
+++ b/resources/views/inc/tabs.blade.php
@@ -58,29 +58,5 @@
         モンスター
     </a>
 
-    <a @class([
-        'nav-link',
-        'flex-lg-fill',
-        'text-lg-center',
-        'text-reset' => !$followeePage,
-        'active' => $followeePage,
-    ]) href="{{ route('users.followees', ['name' => $user->name]) }}" tabindex="-1"
-        aria-disabled="true">
-        <i class="fa-solid fa-users fa-fw"></i>
-        フォロー中<span class="ms-1 fw-bold">{{ $user->followees->count() }}</span>
-    </a>
-
-    <a @class([
-        'nav-link',
-        'flex-lg-fill',
-        'text-lg-center',
-        'text-reset' => !$followerPage,
-        'active' => $followerPage,
-    ]) href="{{ route('users.followers', ['name' => $user->name]) }}" tabindex="-1"
-        aria-disabled="true">
-        <i class="fa-solid fa-user fa-fw"></i>
-        フォロワー<span class="ms-1 fw-bold">{{ $user->followers->count() }}</span>
-    </a>
-
 </nav>
 {{-- /マイページタブ --}}

--- a/resources/views/inc/userInfo.blade.php
+++ b/resources/views/inc/userInfo.blade.php
@@ -6,8 +6,8 @@
             <div class="d-flex justify-content-between align-items-center">
                 {{-- モンスター画像 --}}
                 <a href="{{ route('monsters.show', ['monster' => $user->partner]) }}">
-                    <img src="{{ $user->partner->small_image_path }}" class="rounded-circle border me-2"
-                        alt="モンスター" style="width:3rem;height:3rem;">
+                    <img src="{{ $user->partner->small_image_path }}" class="rounded-circle border me-2" alt="モンスター"
+                        style="width:3rem;height:3rem;">
                 </a>
                 {{-- /モンスター画像 --}}
 
@@ -30,18 +30,30 @@
 
     </div>
     <ul class="list-group list-group-flush">
+
         <li class="list-group-item">
-            <span class="text-muted">相棒モンスター</span>
-            <a href="{{ route('monsters.show', ['monster' => $user->partner]) }}" class="text-reset text-decoration-none">
-                <span id="partner-name" class="fw-bold ms-2">
-                    {{ $user->partner->name }}
-                </span>
-            </a>
+                <a href="{{ route('users.followees', ['name' => $user->name]) }}"
+                    class="text-reset text-decoration-none me-3">
+                    <span class="text-muted me-1">フォロー中</span>
+                    <span class="fw-bold">{{ $user->followees->count() }}</span>
+                </a>
+
+                <a href="{{ route('users.followers', ['name' => $user->name]) }}"
+                    class="text-reset text-decoration-none">
+                    <span class="text-muted me-1">フォロワー</span>
+                    <span class="fw-bold">{{ $user->followers->count() }}</span>
+                </a>
         </li>
 
         <li class="list-group-item">
-            <span class="text-muted">対戦回数</span>
-            <span class="ms-2">{{ $user->battles()->count() }} 回</span>
+            
+            <a href="{{ route('monsters.show', ['monster' => $user->partner]) }}"
+                class="text-reset text-decoration-none">
+                <span class="text-muted me-1">相棒モンスター</span>
+                <span id="partner-name" class="fw-bold">
+                    {{ $user->partner->name }}
+                </span>
+            </a>
         </li>
     </ul>
 </div>

--- a/resources/views/users/battles.blade.php
+++ b/resources/views/users/battles.blade.php
@@ -21,8 +21,6 @@
                     'commentsPage' => false,
                     'battlesPage' => true,
                     'monstersPage' => false,
-                    'followeePage' => false,
-                    'followerPage' => false,
                 ]) {{-- /タブ --}}
 
                 {{-- 対戦履歴一覧 --}}

--- a/resources/views/users/comments.blade.php
+++ b/resources/views/users/comments.blade.php
@@ -21,8 +21,6 @@
                     'commentsPage' => true,
                     'battlesPage' => false,
                     'monstersPage' => false,
-                    'followeePage' => false,
-                    'followerPage' => false,
                 ])
                 {{-- /タブ --}}
 

--- a/resources/views/users/followees.blade.php
+++ b/resources/views/users/followees.blade.php
@@ -14,16 +14,12 @@
                 ])
                 {{-- /ユーザ情報 --}}
 
-                {{-- タブ --}}
-                @include('inc.tabs', [
-                    'postsPage' => false,
-                    'likesPage' => false,
-                    'commentsPage' => false,
-                    'battlesPage' => false,
-                    'monstersPage' => false,
+                {{-- フォロータブ --}}
+                @include('inc.followTabs', [
                     'followeePage' => true,
                     'followerPage' => false,
-                ]) {{-- /タブ --}}
+                ])
+                {{-- /フォロータブ --}}
 
                 {{-- フォロワー一覧 --}}
                 <ul class="list-group mb-3">

--- a/resources/views/users/followers.blade.php
+++ b/resources/views/users/followers.blade.php
@@ -14,16 +14,12 @@
                 ])
                 {{-- /ユーザ情報 --}}
 
-                {{-- タブ --}}
-                @include('inc.tabs', [
-                    'postsPage' => false,
-                    'likesPage' => false,
-                    'commentsPage' => false,
-                    'battlesPage' => false,
-                    'monstersPage' => false,
+                {{-- フォロータブ --}}
+                @include('inc.followTabs', [
                     'followeePage' => false,
                     'followerPage' => true,
-                ]) {{-- /タブ --}}
+                ])
+                {{-- /フォロータブ --}}
 
                 {{-- フォロワー一覧 --}}
                 <ul class="list-group mb-3">

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -25,8 +25,6 @@
                     'commentsPage' => false,
                     'battlesPage' => false,
                     'monstersPage' => false,
-                    'followeePage' => false,
-                    'followerPage' => false,
                 ])
                 {{-- /タブ --}}
 

--- a/resources/views/users/likes.blade.php
+++ b/resources/views/users/likes.blade.php
@@ -25,8 +25,6 @@
                     'commentsPage' => false,
                     'battlesPage' => false,
                     'monstersPage' => false,
-                    'followeePage' => false,
-                    'followerPage' => false,
                 ])
                 {{-- /タブ --}}
 

--- a/resources/views/users/monsters.blade.php
+++ b/resources/views/users/monsters.blade.php
@@ -21,8 +21,6 @@
                     'commentsPage' => false,
                     'battlesPage' => false,
                     'monstersPage' => true,
-                    'followeePage' => false,
-                    'followerPage' => false,
                 ]) {{-- /タブ --}}
 
                 {{-- モンスター一覧 --}}


### PR DESCRIPTION
マイページでフォロー系タブのみ表示するページを作成
ユーザ情報欄にフォロー数を表示するように変更
close #129